### PR TITLE
Disable comment strings and prefer comment patterns

### DIFF
--- a/policy.yml
+++ b/policy.yml
@@ -42,9 +42,7 @@ approval_rules:
         # If a comment contains a string in this list, it counts as approval. Use
         # the "comment_patterns" option if you want to match full comments. The
         # default values are shown.
-        comments:
-          - ":+1:"
-          - "👍"
+        comments: []
 
         # If a comment matches a regular expression in this list, it counts as
         # approval. Defaults to an empty list.


### PR DESCRIPTION
For now we want to avoid matching words in the middle of a comment body and prefer a more strict match.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>